### PR TITLE
Improve inventory page UI - match tabs with reports

### DIFF
--- a/.planning/phases/03-improve-ui-halaman-inventory/03-01-PLAN.md
+++ b/.planning/phases/03-improve-ui-halaman-inventory/03-01-PLAN.md
@@ -1,0 +1,220 @@
+---
+phase: 03-improve-ui-halaman-inventory
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/pages/inventory.ts
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "Halaman inventory terlihat sama dengan halaman pesanan/menu"
+    - "Search functionality bekerja"
+    - "Toolbar dan filter berfungsi"
+    - "Tidak ada regression di fitur existing"
+  artifacts:
+    - path: src/pages/inventory.ts
+      provides: UI halaman inventory yang seragam
+      min_lines: 350
+      contains: card, menu-toolbar, table-container, modal
+  key_links:
+    - from: inventory.ts
+      to: "/inventory"
+      via: Elysia route
+      pattern: "get.*inventory"
+---
+
+<objective>
+Make UI halaman inventory match dengan pattern halaman pesanan/menu
+
+Purpose: Konsisten tampilan antar halaman admin
+Output: inventory.ts dengan UI pattern lengkap
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/3-CONTEXT.md
+@.planning/REQUIREMENTS.md
+@src/pages/inventory.ts
+@src/pages/orders.ts
+@src/pages/menu.ts
+
+# Pattern reference from menu.ts (lines 73-82):
+- `.menu-toolbar` with `.menu-toolbar-left` and `.menu-toolbar-right`
+- Search input with 🔍 emoji placeholder
+- Filter dropdown with `.menu-filter-select`
+
+# Pattern reference from orders.ts (lines 54-70):
+- `.card` > `.card-header`
+- Toolbar uses `.orders-toolbar` (different class name but same structure)
+- Filter dropdown untuk status select
+
+# Current state in inventory.ts:
+- Already uses `.menu-toolbar`, `.menu-toolbar-left`, `.menu-toolbar-right` ✓
+- Already uses `.menu-search-input` and `.menu-filter-select` ✓
+- Already has card > card-header structure ✓
+- Already has table in .table-container ✓
+
+# Minor differences from CONTEXT.md:
+1. Toolbar padding: Has extra padding (0 16px) - line 231: `.inv-tab-content .menu-toolbar { margin-bottom: 16px; padding: 0 16px; }`
+2. Tabs: Uses `.inv-tabs` and `.inv-tab` (unique to inventory - keep this, required for functionality)
+
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Verify toolbar structure matches menu.ts pattern</name>
+  <files>src/pages/inventory.ts</files>
+  <read_first>src/pages/inventory.ts (lines 73-85)</read_first>
+  <action>
+Verify and align toolbar structure with menu.ts pattern:
+
+1. Check `.menu-toolbar` exists (line 73) - already correct
+2. Check `.menu-toolbar-left` section (line 74) - contains search + filter
+3. Check `.menu-toolbar-right` section (line 82) - contains "Tambah Bahan" button
+4. Verify search input has 🔍 in placeholder: `placeholder="🔍 Cari bahan..."` (line 75)
+5. Verify filter dropdown: `<select id="inv-filter-stock" class="menu-filter-select">` (line 76)
+
+Already implemented - verify: grep for these patterns, they should be present.
+  </action>
+  <acceptance_criteria>
+- [ ] .menu-toolbar div present
+- [ ] .menu-toolbar-left contains search input with 🔍 emoji
+- [ ] .menu-filter-select dropdown present
+- [ ] .menu-toolbar-right contains action button
+- [ ] Search triggers filterIngredients() on input
+  </acceptance_criteria>
+  <verify>
+grep -c 'menu-toolbar\|menu-search-input\|menu-filter-select' src/pages/inventory.ts
+  </verify>
+  <done>Toolbar verified - matches menu.ts pattern</done>
+</task>
+
+<task type="auto">
+  <name>Verify table container matches pattern</name>
+  <files>src/pages/inventory.ts</files>
+  <read_first>src/pages/inventory.ts (lines 86-110)</read_first>
+  <action>
+Verify table structure matches standard pattern:
+
+1. Check `.table-container` wraps the table (line 86)
+2. Check `<table class="table">` for styling (line 87)
+3. Check thead with proper headers (line 88)
+4. Check tbody with id for dynamic rendering (line 89)
+5. Check data attributes on rows for filtering: `data-name`, `data-stock`, `data-min`
+
+Already implemented - verify these patterns are present.
+  </action>
+  <acceptance_criteria>
+- [ ] .table-container present around table
+- [ ] Table uses class="table"
+- [ ] Thead with proper column headers
+- [ ] Tbody has id for JavaScript manipulation
+- [ ] Rows have data attributes for filter operations
+  </acceptance_criteria>
+  <verify>
+grep -c 'table-container\|data-name\|data-stock' src/pages/inventory.ts
+  </verify>
+  <done>Table structure verified - matches standard pattern</done>
+</task>
+
+<task type="auto">
+  <name>Test search and filter functionality</name>
+  <files>src/pages/inventory.ts</files>
+  <read_first>src/pages/inventory.ts (lines 255-280)</read_first>
+  <action>
+Verify search/filter JavaScript functions:
+
+1. `filterIngredients()` function (line 255) - called on search input oninput
+2. Function reads: search term from `#inv-search` + stock filter from `#inv-filter-stock`
+3. Filters table rows by name and stock level
+4. Uses data attributes to match: `data-name`, `data-stock`, `data-min`
+
+Verify:
+- Search input has `oninput="filterIngredients()"` (line 75)
+- Filter dropdown has `onchange="filterIngredients()"` (line 76)
+- filterIngredients function filters by name and stock status
+  </action>
+  <acceptance_criteria>
+- [ ] Search input triggers filterIngredients on input
+- [ ] Stock filter dropdown triggers filterIngredients on change
+- [ ] filterIngredients filters by search term
+- [ ] filterIngredients filters by stock level (low/out)
+  </acceptance_criteria>
+  <verify>
+grep -c 'filterIngredients\|inv-search\|inv-filter-stock' src/pages/inventory.ts
+  </verify>
+  <done>Search and filter functionality verified - works on input/change</done>
+</task>
+
+<task type="auto">
+  <name>Verify modal structure matches standard</name>
+  <files>src/pages/inventory.ts</files>
+  <read_first>src/pages/inventory.ts (lines 170-200)</read_first>
+  <action>
+Verify modal structure matches standard pattern:
+
+1. Modal uses `.modal-backdrop` (line 171)
+2. Modal uses `.modal-content` (line 172)
+3. Modal uses `.modal-header` with h3 title (line 173)
+4. Modal uses `.modal-close` for close button (line 173)
+5. Modal uses `.modal-body` for form (line 174)
+6. Modal uses `.modal-footer` for buttons (line 181)
+
+Compare with menu.ts modal structure (lines ~200-230):
+- Same classes used: modal, modal-backdrop, modal-content, modal-header, modal-body, modal-footer, modal-close
+
+Already implemented - verify consistency.
+  </action>
+  <acceptance_criteria>
+- [ ] Modal has backdrop
+- [ ] Modal has content with header/body/footer
+- [ ] Modal has close button with .modal-close
+- [ ] Form has proper input fields
+- [ ] Submit button in footer
+  </acceptance_criteria>
+  <verify>
+grep -c 'modal-backdrop\|modal-content\|modal-close' src/pages/inventory.ts
+  </verify>
+  <done>Modal structure verified - matches standard pattern</done>
+</task>
+
+</tasks>
+
+<verification>
+Code verification:
+1. Check file exists: test -f src/pages/inventory.ts
+2. Build check: bun run build or build command
+3. Syntax check: bun --bun tsc --noEmit
+
+Functional verification (manual):
+1. Visit http://localhost:3000/inventory
+2. Check stats grid at top (4 cards)
+3. Check tabs navigation works
+4. Type in search - table should filter
+5. Select stock filter - table should filter
+6. Click "+ Tambah Bahan" - modal should open
+7. Fill in ingredient details, click Simpan - should save
+</verification>
+
+<success_criteria>
+- [ ] inventory.ts uses card structure with card-header
+- [ ] Toolbar uses .menu-toolbar with left/right sections
+- [ ] Search input has 🔍 emoji in placeholder
+- [ ] Table uses .table in .table-container
+- [ ] Modal has proper structure (backdrop, content, header, body, footer)
+- [ ] Search/filter works
+- [ ] Tabs functionality preserved
+- [ ] No build errors
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-improve-ui-halaman-inventory/03-01-SUMMARY.md`
+</output>

--- a/src/pages/inventory.ts
+++ b/src/pages/inventory.ts
@@ -37,115 +37,102 @@ export const inventoryPage = new Elysia()
         <div class="app-content">
           ${getNavbarHtml('Inventory', 'inventory', user)}
           <main class="app-main">
-            <div class="stats-grid">
-              <div class="stats-card">
-                <div class="stats-label">Total Bahan</div>
-                <div class="stats-value">${total}</div>
-                <div class="stats-change">Semua bahan baku</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-label">Stok Aman</div>
-                <div class="stats-value" style="color: var(--color-success);">${inStock}</div>
-                <div class="stats-change">Stok cukup</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-label">Stok Rendah</div>
-                <div class="stats-value" style="color: var(--color-warning);">${lowStockCount}</div>
-                <div class="stats-change">Perlu restock</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-label">Stok Habis</div>
-                <div class="stats-value" style="color: var(--color-error);">${outOfStock}</div>
-                <div class="stats-change">Tidak tersedia</div>
-              </div>
-            </div>
-
-            <div class="card">
-              <div class="card-header">
-                <div class="inv-tabs">
-                  <button class="inv-tab active" onclick="showInvTab('ingredients', this)">📦 Bahan Baku${lowStockCount + outOfStock > 0 ? ' <span class="badge badge-error" style="font-size:10px;">' + (lowStockCount + outOfStock) + '</span>' : ''}</button>
-                  <button class="inv-tab" onclick="showInvTab('recipes', this)">📋 Resep</button>
-                  <button class="inv-tab" onclick="showInvTab('movements', this)">📊 Riwayat Stok</button>
-                </div>
+            <div class="inv-container">
+              <div class="tab-nav">
+                <button class="tab-btn active" data-tab="ingredients" onclick="showInvTab('ingredients', this)">Bahan Baku${lowStockCount + outOfStock > 0 ? ' <span class="badge badge-error" style="font-size:10px;">' + (lowStockCount + outOfStock) + '</span>' : ''}</button>
+                <button class="tab-btn" data-tab="recipes" onclick="showInvTab('recipes', this)">Resep</button>
+                <button class="tab-btn" data-tab="movements" onclick="showInvTab('movements', this)">Riwayat Stok</button>
               </div>
 
-              <div class="inv-tab-content" id="tab-ingredients">
-                <div class="menu-toolbar">
-                  <div class="menu-toolbar-left">
-                    <input type="text" id="inv-search" class="menu-search-input" placeholder="🔍 Cari bahan..." oninput="filterIngredients()">
-                    <select id="inv-filter-stock" class="menu-filter-select" onchange="filterIngredients()">
-                      <option value="all">Semua</option>
-                      <option value="low">Stok Rendah</option>
-                      <option value="out">Stok Habis</option>
-                    </select>
-                  </div>
-                  <div class="menu-toolbar-right">
-                    <button class="btn btn-primary" onclick="showAddIngredientModal()">+ Tambah Bahan</button>
-                  </div>
+              <div class="tab-content active" id="tab-ingredients">
+                <div class="stats-grid">
+                  <div class="stats-card"><div class="stats-label">Total Bahan</div><div class="stats-value">${total}</div><div class="stats-change">Semua bahan baku</div></div>
+                  <div class="stats-card"><div class="stats-label">Stok Aman</div><div class="stats-value" style="color: var(--color-success);">${inStock}</div><div class="stats-change">Stok cukup</div></div>
+                  <div class="stats-card"><div class="stats-label">Stok Rendah</div><div class="stats-value" style="color: var(--color-warning);">${lowStockCount}</div><div class="stats-change">Perlu restock</div></div>
+                  <div class="stats-card"><div class="stats-label">Stok Habis</div><div class="stats-value" style="color: var(--color-error);">${outOfStock}</div><div class="stats-change">Tidak tersedia</div></div>
                 </div>
-                <div class="table-container">
-                  <table class="table">
-                    <thead><tr><th>Nama</th><th>Satuan</th><th>Stok</th><th>Min Stok</th><th>Harga/Satuan</th><th>Status</th><th>Aksi</th></tr></thead>
-                    <tbody id="ingredients-body">
-                      ${ingredients.map((i: any) => {
-                        const stock = Number(i.currentStock);
-                        const min = Number(i.minStock);
-                        const statusClass = stock === 0 ? 'badge-error' : stock < min ? 'badge-warning' : 'badge-success';
-                        const statusLabel = stock === 0 ? 'Habis' : stock < min ? 'Rendah' : 'OK';
-                        return `<tr data-name="${i.name.toLowerCase()}" data-stock="${stock}" data-min="${min}">
-                          <td><strong>${i.name}</strong></td>
-                          <td>${i.unit}</td>
-                          <td>${stock.toFixed(2)}</td>
-                          <td>${min.toFixed(2)}</td>
-                          <td>Rp ${(i.costPerUnit || 0).toLocaleString('id-ID')}</td>
-                          <td><span class="badge ${statusClass}">${statusLabel}</span></td>
-                          <td>
-                            <button onclick="showEditIngredientModal(${i.id}, '${i.name.replace(/'/g, "\\'")}', '${i.unit}', ${stock}, ${min}, ${i.costPerUnit || 0})" class="btn btn-secondary btn-sm">Edit</button>
-                            <button onclick="showStockAdjustModal(${i.id}, '${i.name.replace(/'/g, "\\'")}', ${stock})" class="btn btn-warning btn-sm">Stok</button>
-                          </td>
-                        </tr>`;
-                      }).join('')}
-                    </tbody>
-                  </table>
+
+                <div class="card">
+                  <div class="menu-toolbar">
+                    <div class="menu-toolbar-left">
+                      <input type="text" id="inv-search" class="menu-search-input" placeholder="Cari bahan..." oninput="filterIngredients()">
+                      <select id="inv-filter-stock" class="menu-filter-select" onchange="filterIngredients()">
+                        <option value="all">Semua</option>
+                        <option value="low">Stok Rendah</option>
+                        <option value="out">Stok Habis</option>
+                      </select>
+                    </div>
+                    <div class="menu-toolbar-right">
+                      <button class="btn btn-primary" onclick="showAddIngredientModal()">+ Tambah Bahan</button>
+                    </div>
+                  </div>
+                  <div class="table-container">
+                    <table class="table">
+                      <thead><tr><th>Nama</th><th>Satuan</th><th>Stok</th><th>Min Stok</th><th>Harga/Satuan</th><th>Status</th><th>Aksi</th></tr></thead>
+                      <tbody id="ingredients-body">
+                        ${ingredients.map((i: any) => {
+                          const stock = Number(i.currentStock);
+                          const min = Number(i.minStock);
+                          const statusClass = stock === 0 ? 'badge-error' : stock < min ? 'badge-warning' : 'badge-success';
+                          const statusLabel = stock === 0 ? 'Habis' : stock < min ? 'Rendah' : 'OK';
+                          return `<tr data-name="${i.name.toLowerCase()}" data-stock="${stock}" data-min="${min}">
+                            <td><strong>${i.name}</strong></td>
+                            <td>${i.unit}</td>
+                            <td>${stock.toFixed(2)}</td>
+                            <td>${min.toFixed(2)}</td>
+                            <td>Rp ${(i.costPerUnit || 0).toLocaleString('id-ID')}</td>
+                            <td><span class="badge ${statusClass}">${statusLabel}</span></td>
+                            <td>
+                              <button onclick="showEditIngredientModal(${i.id}, '${i.name.replace(/'/g, "\\'")}', '${i.unit}', ${stock}, ${min}, ${i.costPerUnit || 0})" class="btn btn-secondary btn-sm">Edit</button>
+                              <button onclick="showStockAdjustModal(${i.id}, '${i.name.replace(/'/g, "\\'")}', ${stock})" class="btn btn-warning btn-sm">Stok</button>
+                            </td>
+                          </tr>`;
+                        }).join('')}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
 
-              <div class="inv-tab-content" id="tab-recipes" style="display: none;">
-                <div class="menu-toolbar">
-                  <div class="menu-toolbar-left">
-                    <select id="recipe-menu-select" class="menu-filter-select" onchange="loadRecipe()">
-                      <option value="">— Pilih Menu —</option>
-                      ${menus.map((m: any) => `<option value="${m.id}">${m.name}</option>`).join('')}
-                    </select>
+              <div class="tab-content" id="tab-recipes">
+                <div class="card">
+                  <div class="menu-toolbar">
+                    <div class="menu-toolbar-left">
+                      <select id="recipe-menu-select" class="menu-filter-select" onchange="loadRecipe()">
+                        <option value="">— Pilih Menu —</option>
+                        ${menus.map((m: any) => `<option value="${m.id}">${m.name}</option>`).join('')}
+                      </select>
+                    </div>
+                    <div class="menu-toolbar-right">
+                      <button class="btn btn-primary" onclick="showAddRecipeModal()" id="btn-add-recipe" style="display: none;">+ Tambah Bahan</button>
+                    </div>
                   </div>
-                  <div class="menu-toolbar-right">
-                    <button class="btn btn-primary" onclick="showAddRecipeModal()" id="btn-add-recipe" style="display: none;">+ Tambah Bahan</button>
+                  <div id="recipe-content">
+                    <p class="text-muted text-center" style="padding: 40px;">Pilih menu untuk melihat resep</p>
                   </div>
-                </div>
-                <div id="recipe-content">
-                  <p class="text-muted text-center" style="padding: 40px;">Pilih menu untuk melihat resep</p>
                 </div>
               </div>
 
-              <div class="inv-tab-content" id="tab-movements" style="display: none;">
-                <div class="menu-toolbar">
-                  <div class="menu-toolbar-left">
-                    <input type="text" id="mov-search" class="menu-search-input" placeholder="🔍 Cari..." oninput="filterMovements()">
-                    <select id="mov-filter-type" class="menu-filter-select" onchange="filterMovements()">
-                      <option value="all">Semua Tipe</option>
-                      <option value="in">📥 Masuk</option>
-                      <option value="out">📤 Keluar</option>
-                      <option value="adjustment">🔄 Adjustment</option>
-                      <option value="waste">🗑️ Waste</option>
-                    </select>
+              <div class="tab-content" id="tab-movements">
+                <div class="card">
+                  <div class="menu-toolbar">
+                    <div class="menu-toolbar-left">
+                      <input type="text" id="mov-search" class="menu-search-input" placeholder="Cari..." oninput="filterMovements()">
+                      <select id="mov-filter-type" class="menu-filter-select" onchange="filterMovements()">
+                        <option value="all">Semua Tipe</option>
+                        <option value="in">📥 Masuk</option>
+                        <option value="out">📤 Keluar</option>
+                        <option value="adjustment">🔄 Adjustment</option>
+                        <option value="waste">🗑️ Waste</option>
+                      </select>
+                    </div>
+                    <div class="menu-toolbar-right"></div>
                   </div>
-                  <div class="menu-toolbar-right"></div>
-                </div>
-                <div class="table-container">
-                  <table class="table">
-                    <thead><tr><th>Tanggal</th><th>Bahan</th><th>Tipe</th><th>Jumlah</th><th>Keterangan</th></tr></thead>
-                    <tbody id="movements-body">
-                      ${movements.map((m: any) => {
+                  <div class="table-container">
+                    <table class="table">
+                      <thead><tr><th>Tanggal</th><th>Bahan</th><th>Tipe</th><th>Jumlah</th><th>Keterangan</th></tr></thead>
+                      <tbody id="movements-body">
+                        ${movements.map((m: any) => {
                         const typeIcons: Record<string, string> = { in: '📥', out: '📤', adjustment: '🔄', waste: '🗑️' };
                         const typeColors: Record<string, string> = { in: 'badge-success', out: 'badge-primary', adjustment: 'badge-warning', waste: 'badge-error' };
                         return `<tr data-type="${m.type}" data-reason="${(m.reason || '').toLowerCase()}">
@@ -227,13 +214,17 @@ export const inventoryPage = new Elysia()
       </div>
 
       <style>
-        .inv-tab-content { padding: 0; }
-        .inv-tab-content .menu-toolbar { margin-bottom: 16px; padding: 0 16px; }
-        .inv-tab-content .table-container { padding: 0 16px 16px; }
-        .inv-tabs { display: flex; gap: 4px; }
-        .inv-tab { padding: 8px 16px; border: 1px solid var(--color-border); border-radius: var(--radius-md) var(--radius-md) 0 0; background: var(--color-bg); cursor: pointer; font-size: 13px; font-weight: 500; transition: var(--transition); }
-        .inv-tab:hover { background: var(--color-bg-hover); }
-        .inv-tab.active { background: var(--color-primary); color: white; border-color: var(--color-primary); }
+        .tab-content { padding: 0; }
+        .tab-content .menu-toolbar { margin-bottom: 16px; padding: 0 16px; }
+        .tab-content .table-container { padding: 0 16px 16px; }
+        .tab-nav { display: flex; gap: 4px; margin-bottom: 24px; background: var(--color-bg); border-radius: var(--radius-md); padding: 4px; border: 1px solid var(--color-border); }
+        .tab-btn { flex: 1; padding: 12px 24px; border: none; background: transparent; cursor: pointer; border-radius: var(--radius-sm); font-size: 14px; font-weight: 500; color: var(--color-text-secondary); transition: var(--transition); }
+        .tab-btn:hover { background: var(--color-bg-alt); color: var(--color-text); }
+        .tab-btn.active { background: var(--color-primary); color: white; }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+        .inv-container { max-width: 1400px; }
+        .reports-container { max-width: 1400px; }
         .menu-toolbar { display: flex; justify-content: space-between; align-items: center; width: 100%; flex-wrap: wrap; gap: 8px; }
         .menu-toolbar-left { display: flex; gap: 8px; flex: 1; flex-wrap: wrap; }
         .menu-toolbar-right { display: flex; gap: 8px; }
@@ -246,9 +237,9 @@ export const inventoryPage = new Elysia()
       </style>
       <script>
         function showInvTab(tab, btn) {
-          document.querySelectorAll('.inv-tab-content').forEach(c => c.style.display = 'none');
-          document.querySelectorAll('.inv-tab').forEach(t => t.classList.remove('active'));
-          document.getElementById('tab-' + tab).style.display = 'block';
+          document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+          document.querySelectorAll('.tab-btn').forEach(t => t.classList.remove('active'));
+          document.getElementById('tab-' + tab).classList.add('active');
           btn.classList.add('active');
         }
 


### PR DESCRIPTION
## Summary
- Match inventory tabs with reports page design
- Fix tab click not working (use .active class)
- Add .inv-container wrapper for full width
- Remove emojis from tabs and search placeholders
- Each tab content wrapped in .card

## Changes
- src/pages/inventory.ts: 
  - Replace .inv-tabs/.inv-tab with .tab-nav/.tab-btn
  - Use class-based active state instead of display:none
  - Add .inv-container wrapper
  - Wrap each tab content in .card
  - Remove emojis from placeholders and tab labels

## Testing
- Tabs now click properly and show content
- Inventory page matches reports page layout
- Tabs at top with same size and styling